### PR TITLE
refactor: improve document number validation in altaTitular function

### DIFF
--- a/src/titular.c
+++ b/src/titular.c
@@ -23,7 +23,9 @@ void altaTitular() {
     fgets(nuevo.tipoDocumento, sizeof(nuevo.tipoDocumento), stdin);
     nuevo.tipoDocumento[strcspn(nuevo.tipoDocumento, "\n")] = '\0';
 
-    leerEnteroValidado("Ingrese numero de documento: ", &nuevo.nroDocumento);
+    do {
+         leerEnteroValidado("Ingrese numero de documento: ", &nuevo.nroDocumento);
+    } while (titularExiste(nuevo.nroDocumento));
 
     printf("Ingrese fecha de nacimiento (dd/mm/aaaa): ");
     fgets(nuevo.fechaNacimiento, sizeof(nuevo.fechaNacimiento), stdin);

--- a/test/test.c
+++ b/test/test.c
@@ -15,7 +15,8 @@ void testRegistro();
 void testTitular();
 
 
-// gcc test.c automotor.c cedula.c titular.c historialevento.c registro.c domicilio.c utils.c -o test
+// gcc -Iinclude test/test.c src/titular.c src/automotor.c src/cedula.c src/historialevento.c src/registro.c src/domicilio.c src/utils.c -o test.exe
+
 
 int main(){
 
@@ -23,11 +24,11 @@ int main(){
     
     //testHistorialEvento();
 
-    testCedula();
+    // testCedula();
 
     //testDomicilio();
 
-    //testTitular();
+    testTitular();
 
     //testRegistro();
 


### PR DESCRIPTION
This pull request includes changes to improve the validation logic in the `altaTitular` function and updates the test configuration and execution in the `test/test.c` file.

### Validation improvements:
* [`src/titular.c`](diffhunk://#diff-8d81b75b0a9b2b2f156427a4a8771dd472c6f1109f797ddfafe193d03fd8cbffR26-R28): Added a loop to ensure that the document number entered in `altaTitular` is validated against existing records using the `titularExiste` function. This prevents duplicate entries for the same document number.

### Test configuration and execution updates:
* [`test/test.c`](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L18-R31): Updated the compilation command to include the `include` directory and changed the output file name to `test.exe` for clarity.
* [`test/test.c`](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L18-R31): Adjusted test execution by commenting out `testCedula()` and enabling `testTitular()` to focus on testing the titular functionality.